### PR TITLE
Migrate to Fedora Messaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Pull Requests
 
 - (@ralphbean)      #10, Try again later when we're unable to wrap meetbot.
   https://github.com/fedora-infra/supybot-fedmsg/pull/10
+- (@abompard)       #12, Migrate to Fedora Messaging.
+  https://github.com/fedora-infra/supybot-fedmsg/pull/12
 
 Commits
 

--- a/fedora-messaging.toml.example
+++ b/fedora-messaging.toml.example
@@ -1,0 +1,13 @@
+# Example configuraton for Fedora Messaging
+
+# Broker address
+amqp_url = "amqp://"
+
+# Authentication is TLS-based
+[tls]
+ca_cert = "/etc/pki/tls/certs/ca-bundle.crt"
+keyfile = "/my/client/key.pem"
+certfile = "/my/client/cert.pem"
+
+[client_properties]
+app = "supybot-fedmsg"

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
 passenv = HOME
 
 [testenv:lint]
+basepython = python2
 deps =
     flake8 > 3.0
 commands =


### PR DESCRIPTION
Replace the call to fedmsg by the Fedora Messaging API.